### PR TITLE
SQL support fix + collate fix

### DIFF
--- a/vorp_pre-made.sql
+++ b/vorp_pre-made.sql
@@ -124,7 +124,7 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `crafting` longtext COLLATE utf8mb4_bin DEFAULT '{"medical":0,"blacksmith":0,"basic":0,"survival":0,"brewing":0,"food":0}',
   `info` longtext COLLATE utf8mb4_bin DEFAULT '{}',
   `gunsmith` double(11,2) DEFAULT 0.00,
-  `ammo` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4 DEFAULT '{}',
+  `ammo` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT '{}',
   UNIQUE KEY `identifier_charidentifier` (`identifier`,`charidentifier`) USING BTREE,
   KEY `charidentifier` (`charidentifier`) USING BTREE,
   INDEX `ammo` (`ammo`) USING BTREE,


### PR DESCRIPTION
What this changes:
1. SQL Error (1273): Unknown collation: 'utf8mb4' should now be fixed
2. Ammo swapped from a longtext to a varchar for mysql support